### PR TITLE
Robustness and portability fixes: clean interrupts, FFmpeg stderr drain, Windows CI, remote timeout

### DIFF
--- a/src/sshdesk/capture/ffmpeg.py
+++ b/src/sshdesk/capture/ffmpeg.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import hashlib
 import subprocess
+import threading
 import time
+from collections import deque
 from pathlib import Path
+from typing import BinaryIO
 
 from PIL import Image
+
+_STDERR_CHUNK = 256
+_STDERR_CHUNKS_KEPT = 8
 
 
 class FFmpegX11Capture:
@@ -26,6 +32,8 @@ class FFmpegX11Capture:
         self.frames_per_second = 60.0
         self._process: subprocess.Popen[bytes] | None = None
         self._buffer = bytearray()
+        self._stderr_chunks: deque[bytes] = deque(maxlen=_STDERR_CHUNKS_KEPT)
+        self._stderr_thread: threading.Thread | None = None
 
     def set_target_size(self, width: int, height: int) -> None:
         target = width, height
@@ -80,7 +88,25 @@ class FFmpegX11Capture:
             bufsize=0,
             close_fds=True,
         )
+        self._stderr_chunks.clear()
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr, args=(self._process.stderr,), daemon=True
+        )
+        self._stderr_thread.start()
         self._buffer = bytearray(width * height * 3)
+
+    def _drain_stderr(self, stream: BinaryIO | None) -> None:
+        """Keep the pipe drained so a chatty ffmpeg cannot block on stderr writes."""
+        if stream is None:
+            return
+        try:
+            for chunk in iter(lambda: stream.read(_STDERR_CHUNK), b""):
+                self._stderr_chunks.append(chunk)
+        except (OSError, ValueError):
+            pass
+
+    def _stderr_detail(self) -> str:
+        return b"".join(self._stderr_chunks)[:2048].decode(errors="replace").strip()
 
     def capture(self) -> tuple[Image.Image, int, bytes]:
         self._start()
@@ -92,9 +118,7 @@ class FFmpegX11Capture:
         while offset < len(view):
             count = process.stdout.readinto(view[offset:])
             if not count:
-                detail = ""
-                if process.stderr is not None:
-                    detail = process.stderr.read(2048).decode(errors="replace").strip()
+                detail = self._stderr_detail()
                 self._stop()
                 suffix = f": {detail}" if detail else ""
                 raise OSError(f"FFmpeg X11 capture stream ended{suffix}")
@@ -119,7 +143,13 @@ class FFmpegX11Capture:
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=1.0)
-        if process.stderr is not None:
+        thread = self._stderr_thread
+        self._stderr_thread = None
+        if thread is not None:
+            # Process exit closes the stderr read end, so the drain loop ends on its own.
+            thread.join(timeout=1.0)
+        if process.stderr is not None and (thread is None or not thread.is_alive()):
+            # Never close under a live reader thread.
             process.stderr.close()
 
     def close(self) -> None:

--- a/src/sshdesk/cli.py
+++ b/src/sshdesk/cli.py
@@ -75,10 +75,14 @@ def _login_shell() -> str:
     return shell
 
 
+def _shell_arguments(shell: str) -> list[str]:
+    # cmd.exe and PowerShell have no login-shell mode; POSIX shells use -l.
+    return [shell] if os.name == "nt" else [shell, "-l"]
+
+
 def _exec_shell() -> int:
     shell = _login_shell()
-    arguments = [shell] if os.name == "nt" else [shell, "-l"]
-    os.execv(shell, arguments)
+    os.execv(shell, _shell_arguments(shell))
     return 0
 
 

--- a/src/sshdesk/cli.py
+++ b/src/sshdesk/cli.py
@@ -7,11 +7,12 @@ import shutil
 import sys
 from pathlib import Path
 
+from sshdesk.capture.base import ScreenCapture
 from sshdesk.platform import create_capture
 from sshdesk.render import TerminalRenderer, TerminalWriter
 
 
-def _capture(name: str):
+def _capture(name: str) -> ScreenCapture:
     return create_capture(name)
 
 

--- a/src/sshdesk/client.py
+++ b/src/sshdesk/client.py
@@ -14,6 +14,7 @@ from sshdesk.agent import BUTTONS, KEY_NAMES
 
 TARGET_RE = re.compile(r"^[A-Za-z0-9_.%+@:-]{1,255}$")
 MAX_REMOTE_RESPONSE = 64 * 1024 * 1024
+DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
 def _split_arguments(target: str, direction: str, size: int, pane: str) -> list[str]:
@@ -74,7 +75,11 @@ def split_entrypoint(argv: list[str] | None = None) -> int:
         raise
 
 
-def _remote_request(target: str, request: dict[str, object]) -> dict[str, object]:
+def _remote_request(
+    target: str,
+    request: dict[str, object],
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> dict[str, object]:
     ssh = shutil.which("ssh")
     if ssh is None:
         raise RuntimeError("OpenSSH ssh is required")
@@ -84,7 +89,7 @@ def _remote_request(target: str, request: dict[str, object]) -> dict[str, object
         input=payload,
         capture_output=True,
         check=False,
-        timeout=30,
+        timeout=timeout,
     )
     if process.returncode != 0:
         detail = process.stderr.decode(errors="replace").strip()
@@ -108,6 +113,12 @@ def remote_entrypoint(argv: list[str] | None = None) -> int:
         description="Observe or control an SSHDESK host through ordinary OpenSSH",
     )
     parser.add_argument("target", help="OpenSSH target, for example user@host")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help="seconds to wait for a one-shot agent response (default: 30)",
+    )
     commands = parser.add_subparsers(dest="command", required=True)
     commands.add_parser("info")
     screenshot = commands.add_parser("screenshot", aliases=["observe"])
@@ -137,6 +148,8 @@ def remote_entrypoint(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if not TARGET_RE.fullmatch(args.target):
         parser.error("target contains unsupported characters")
+    if not 0 < args.timeout:
+        parser.error("--timeout must be a positive number of seconds")
     if args.command == "session":
         ssh = shutil.which("ssh")
         if ssh is None:
@@ -162,7 +175,7 @@ def remote_entrypoint(argv: list[str] | None = None) -> int:
         request.update(key=args.key, ctrl=args.ctrl, alt=args.alt, shift=args.shift)
 
     try:
-        response = _remote_request(args.target, request)
+        response = _remote_request(args.target, request, timeout=args.timeout)
         if args.command == "info":
             response.pop("id", None)
             response.pop("ok", None)
@@ -175,6 +188,10 @@ def remote_entrypoint(argv: list[str] | None = None) -> int:
             else:
                 Path(args.output).write_bytes(image)
         return 0
+    except subprocess.TimeoutExpired as exc:
+        limit = exc.timeout if exc.timeout is not None else args.timeout
+        print(f"sshdesk-remote: timed out after {limit:g} seconds", file=sys.stderr)
+        return 1
     except (KeyError, OSError, RuntimeError, ValueError) as exc:
         print(f"sshdesk-remote: {exc}", file=sys.stderr)
         return 1

--- a/src/sshdesk/render/capabilities.py
+++ b/src/sshdesk/render/capabilities.py
@@ -59,7 +59,7 @@ class TerminalCapabilities:
 
         mouse_override = env.get("SSHDESK_MOUSE", "auto").strip().lower()
         if mouse_override not in {"auto", "0", "1", "false", "true", "no", "yes"}:
-            raise RuntimeError("SSHDESK_MOUSE must be auto, 0, or 1")
+            raise RuntimeError("SSHDESK_MOUSE must be auto, 0/1, false/true, or no/yes")
         mouse = mouse_override not in {"0", "false", "no"}
         # SGR is understood by modern xterm-compatible emulators. When ignored,
         # terminals normally fall back to the legacy X10 report, which we parse too.
@@ -69,7 +69,7 @@ class TerminalCapabilities:
         )
         unicode_override = env.get("SSHDESK_UNICODE", "auto").strip().lower()
         if unicode_override not in {"auto", "0", "1", "false", "true", "no", "yes"}:
-            raise RuntimeError("SSHDESK_UNICODE must be auto, 0, or 1")
+            raise RuntimeError("SSHDESK_UNICODE must be auto, 0/1, false/true, or no/yes")
         if unicode_override in {"0", "false", "no"}:
             unicode = False
         elif unicode_override in {"1", "true", "yes"}:

--- a/src/sshdesk/session/direct.py
+++ b/src/sshdesk/session/direct.py
@@ -616,6 +616,9 @@ class DirectSession:
         except (OSError, RuntimeError, ValueError) as exc:
             print(f"sshdesk-server: {exc}", file=sys.stderr)
             return 1
+        except KeyboardInterrupt:
+            # Cleanup still runs via the finally block; 130 mirrors shell SIGINT convention.
+            return 130
         finally:
             self.stop_event.set()
             self._wake_event.set()

--- a/src/sshdesk/session/server.py
+++ b/src/sshdesk/session/server.py
@@ -117,6 +117,9 @@ def server_entrypoint(argv: list[str] | None = None) -> int:
     except (OSError, RuntimeError, ValueError) as exc:
         print(f"sshdesk-server: {exc}", file=sys.stderr)
         return 1
+    except KeyboardInterrupt:
+        # Cleanup still runs via the finally block; 130 mirrors shell SIGINT convention.
+        return 130
     finally:
         if input_backend is not None:
             input_backend.close()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -10,7 +11,7 @@ from sshdesk.agent import (
     agent_ssh_entrypoint,
 )
 from sshdesk.capture.synthetic import SyntheticCapture
-from sshdesk.cli import forced_command_main
+from sshdesk.cli import _shell_arguments, forced_command_main
 from sshdesk.client import _remote_request, _split_arguments
 from sshdesk.input.base import InputBackend
 from sshdesk.input.events import KeyCode, KeyEvent, Modifiers
@@ -85,7 +86,29 @@ class AgentTests(unittest.TestCase):
             "sshdesk.cli.os.execv"
         ) as execv:
             self.assertEqual(forced_command_main(), 0)
-        execv.assert_called_once_with("/bin/bash", ["/bin/bash", "-l"])
+        arguments = ["/bin/bash"] if os.name == "nt" else ["/bin/bash", "-l"]
+        execv.assert_called_once_with("/bin/bash", arguments)
+
+    def test_login_shell_arguments_match_each_platform(self) -> None:
+        # Regression test for the Windows portable job: cmd.exe rejects -l.
+        with patch("sshdesk.cli.os.name", "posix"):
+            self.assertEqual(_shell_arguments("/bin/bash"), ["/bin/bash", "-l"])
+        with patch("sshdesk.cli.os.name", "nt"):
+            self.assertEqual(_shell_arguments("/bin/bash"), ["/bin/bash"])
+            self.assertEqual(_shell_arguments("cmd.exe"), ["cmd.exe"])
+
+    def test_windows_shell_selector_execs_without_login_flag(self) -> None:
+        environment = {"SSH_ORIGINAL_COMMAND": "shell"}
+        shell = "C:/Windows/system32/cmd.exe"
+        with patch.dict("os.environ", environment, clear=True), patch(
+            "sshdesk.cli.os.name", "nt"
+        ), patch(
+            "sshdesk.cli._has_interactive_terminal", return_value=True
+        ), patch(
+            "sshdesk.cli._login_shell", return_value=shell
+        ), patch("sshdesk.cli.os.execv") as execv:
+            self.assertEqual(forced_command_main(), 0)
+        execv.assert_called_once_with(shell, [shell])
 
     def test_portable_forced_command_requires_pty_for_shell_selector(self) -> None:
         environment = {"SSH_ORIGINAL_COMMAND": "shell"}
@@ -192,6 +215,7 @@ class AgentTests(unittest.TestCase):
             run.call_args.args[0],
             ["/usr/bin/ssh", "alice@example.com", "sshdesk-agent", "session"],
         )
+        self.assertEqual(run.call_args.kwargs["timeout"], 30.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import io
 import os
+import subprocess
 import unittest
+from contextlib import redirect_stderr
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -12,7 +15,11 @@ from sshdesk.agent import (
 )
 from sshdesk.capture.synthetic import SyntheticCapture
 from sshdesk.cli import _shell_arguments, forced_command_main
-from sshdesk.client import _remote_request, _split_arguments
+from sshdesk.client import (
+    _remote_request,
+    _split_arguments,
+    remote_entrypoint,
+)
 from sshdesk.input.base import InputBackend
 from sshdesk.input.events import KeyCode, KeyEvent, Modifiers
 from sshdesk.input.ydotool import YdotoolInput
@@ -216,6 +223,32 @@ class AgentTests(unittest.TestCase):
             ["/usr/bin/ssh", "alice@example.com", "sshdesk-agent", "session"],
         )
         self.assertEqual(run.call_args.kwargs["timeout"], 30.0)
+
+    def test_remote_request_timeout_is_configurable(self) -> None:
+        completed = SimpleNamespace(returncode=0, stdout=b'{"ok":true}\n', stderr=b"")
+        with patch("sshdesk.client.shutil.which", return_value="/usr/bin/ssh"), patch(
+            "sshdesk.client.subprocess.run", return_value=completed
+        ) as run:
+            _remote_request(
+                "alice@example.com", {"id": 1, "action": "observe"}, timeout=120.0
+            )
+        self.assertEqual(run.call_args.kwargs["timeout"], 120.0)
+
+    def test_remote_reports_timeout_expiry_without_traceback(self) -> None:
+        stderr = io.StringIO()
+        with patch("sshdesk.client.shutil.which", return_value="/usr/bin/ssh"), patch(
+            "sshdesk.client.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ssh", timeout=45),
+        ), redirect_stderr(stderr):
+            self.assertEqual(remote_entrypoint(["alice@example.com", "info"]), 1)
+        self.assertIn("timed out after 45 seconds", stderr.getvalue())
+
+    def test_remote_rejects_non_positive_timeout(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+            remote_entrypoint(["alice@example.com", "--timeout", "0", "info"])
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--timeout must be a positive number of seconds", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sshdesk.agent import (
+    MAX_COMMAND_LENGTH,
+    AgentController,
+    run_agent_session,
+)
+from sshdesk.capture.synthetic import SyntheticCapture
+from sshdesk.input.base import InputBackend
+from sshdesk.session.server import server_entrypoint
+
+
+class RecordingInput(InputBackend):
+    def __init__(self) -> None:
+        self.events: list[tuple[object, ...]] = []
+
+    def key(self, event: object) -> None:
+        self.events.append(("key", event))
+
+    def move(self, x: int, y: int) -> None:
+        self.events.append(("move", x, y))
+
+    def button(self, button: int, pressed: bool, x: int, y: int) -> None:
+        self.events.append(("button", button, pressed, x, y))
+
+    def scroll(self, amount: int, x: int, y: int) -> None:
+        self.events.append(("scroll", amount, x, y))
+
+
+class AgentSessionTests(unittest.TestCase):
+    def controller(self) -> tuple[AgentController, RecordingInput]:
+        controller = AgentController()
+        backend = RecordingInput()
+        controller._capture = SyntheticCapture(320, 180, animate=False)
+        controller._input = backend
+        return controller, backend
+
+    def run_session(
+        self,
+        controller: AgentController,
+        lines: list[str],
+    ) -> tuple[int, list[dict[str, object]]]:
+        payload = "".join(line + "\n" for line in lines).encode()
+        output = io.BytesIO()
+        wrapper = io.TextIOWrapper(output)
+        with patch.object(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(payload))), patch.object(
+            sys, "stdout", wrapper
+        ):
+            code = run_agent_session(controller)
+        wrapper.detach()
+        return code, [json.loads(line) for line in output.getvalue().splitlines()]
+
+    def test_info_and_quit_stop_the_session(self) -> None:
+        controller, _backend = self.controller()
+        quit_line = json.dumps({"id": 1, "action": "quit"})
+        info_line = json.dumps({"id": 2, "action": "info"})
+        platform = SimpleNamespace(
+            system="Linux", session="x11", capture="synthetic", input="null"
+        )
+        with patch("sshdesk.agent.detect_platform", return_value=platform):
+            code, responses = self.run_session(controller, [info_line, quit_line, info_line])
+        self.assertEqual(code, 0)
+        self.assertEqual(len(responses), 2)
+        self.assertTrue(responses[0]["ok"])
+        self.assertEqual(responses[0]["width"], 320)
+        self.assertTrue(responses[1]["quit"])
+
+    def test_errors_keep_the_session_alive(self) -> None:
+        controller, backend = self.controller()
+        lines = [
+            "{not json",
+            "[1, 2]",
+            json.dumps({"id": 3, "action": "teleport"}),
+            json.dumps({"id": 4, "action": "move", "x": 999_999, "y": 0}),
+            json.dumps({"id": 5, "action": "move", "x": 7, "y": 9}),
+        ]
+        code, responses = self.run_session(controller, lines)
+        self.assertEqual(code, 0)
+        self.assertEqual(len(responses), len(lines))
+        self.assertFalse(responses[0]["ok"])
+        self.assertIsNone(responses[0]["id"])
+        self.assertIn("JSON object", responses[1]["error"])
+        self.assertIn("unknown action", responses[2]["error"])
+        self.assertIn("coordinate", responses[3]["error"])
+        self.assertTrue(responses[4]["ok"])
+        self.assertIn(("move", 7, 9), backend.events)
+
+    def test_oversized_requests_are_rejected_without_parsing(self) -> None:
+        controller, backend = self.controller()
+        oversized = "x" * (MAX_COMMAND_LENGTH + 1)
+        code, responses = self.run_session(
+            controller,
+            [oversized, json.dumps({"id": 6, "action": "quit"})],
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(responses[0], {"ok": False, "error": "request is too large"})
+        self.assertEqual(backend.events, [])
+
+
+class ServerInterruptTests(unittest.TestCase):
+    def test_keyboard_interrupt_during_startup_exits_cleanly(self) -> None:
+        with patch("sshdesk.session.server.create_capture", side_effect=KeyboardInterrupt):
+            self.assertEqual(server_entrypoint([]), 130)
+
+    def test_keyboard_interrupt_from_session_exits_cleanly(self) -> None:
+        with patch(
+            "sshdesk.session.direct.DirectSession.run",
+            side_effect=KeyboardInterrupt,
+        ):
+            self.assertEqual(
+                server_entrypoint(["--capture", "synthetic", "--no-input"]),
+                130,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import io
 import subprocess
 import threading
 import unittest
+from collections import deque
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from PIL import Image
 
+from sshdesk.capture.ffmpeg import FFmpegX11Capture
 from sshdesk.capture.gnome import GnomeScreenCastCapture
 from sshdesk.capture.native import NativeCapture, grab_macos_display
 from sshdesk.capture.wayland import WaylandCapture
@@ -186,6 +190,60 @@ class GnomeCaptureTests(unittest.TestCase):
                 (capture.REMOTE_NAME, "/remote/session", "Stop"),
             ],
         )
+
+
+class FFmpegCaptureTests(unittest.TestCase):
+    def _capture(self) -> FFmpegX11Capture:
+        capture = object.__new__(FFmpegX11Capture)
+        capture._stderr_chunks = deque(maxlen=8)
+        capture._stderr_thread = None
+        return capture
+
+    def test_stderr_drain_keeps_tail_and_survives_closed_stream(self) -> None:
+        capture = self._capture()
+        stream = io.BytesIO(b"x" * 4096 + b"frame dropped")
+        capture._stderr_chunks.clear()
+        capture._drain_stderr(stream)
+        detail = capture._stderr_detail()
+        self.assertTrue(detail.endswith("frame dropped"))
+        self.assertLessEqual(len(detail), 2048)
+
+    def test_stderr_drain_ignores_read_errors(self) -> None:
+        class BrokenStream:
+            def read(self, _size: int) -> bytes:
+                raise OSError("closed")
+
+        capture = self._capture()
+        capture._stderr_chunks.clear()
+        capture._drain_stderr(BrokenStream())
+        self.assertEqual(capture._stderr_detail(), "")
+        capture._drain_stderr(None)
+
+    def test_capture_reports_drained_stderr_after_stream_ends(self) -> None:
+        capture = self._capture()
+        capture._buffer = bytearray(10)
+        capture._stderr_chunks.clear()
+        capture._stderr_chunks.append(b"capturer error")
+        capture._process = SimpleNamespace(
+            stdout=io.BytesIO(b""),
+            stderr=None,
+            poll=lambda: 1,
+            terminate=lambda: None,
+        )
+
+        with self.assertRaisesRegex(OSError, "stream ended: capturer error"):
+            capture.capture()
+        self.assertIsNone(capture._process)
+
+    def test_set_frame_rate_bounds_are_enforced(self) -> None:
+        capture = self._capture()
+        capture.frames_per_second = 60.0
+        capture.target_size = (64, 64)
+        capture._stop = lambda: None
+        capture.set_frame_rate(30.0)
+        self.assertEqual(capture.frames_per_second, 30.0)
+        with self.assertRaisesRegex(ValueError, "between 0.5 and 120"):
+            capture.set_frame_rate(500.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A set of focused robustness and portability fixes across the session, capture, agent, and client paths. Six self-contained commits, each verified independently so the branch stays bisect-safe.

## Clean Ctrl+C exits
`KeyboardInterrupt` escaping `server_entrypoint` / `DirectSession.run` printed a raw traceback when raised before raw mode engaged or during teardown. Both handlers now return exit code 130 (shell SIGINT convention); existing `finally` cleanup still runs.

## FFmpeg stderr drain
The X11 FFmpeg backend used `stderr=PIPE` but only read it after the stream ended. A chatty long-lived ffmpeg could fill the 64 KB pipe buffer, block on its next stderr write, and deadlock capture mid-session. A daemon thread now drains stderr into a bounded deque (~2 KB tail), which is also surfaced in the stream-end error message. Teardown joins the thread before closing the pipe and never closes it under a live reader.

## Windows portable job fix
The `windows-latest` job failed because the forced-command shell selector test asserted a `-l` login argument that `_exec_shell` deliberately omits on Windows, where cmd.exe/PowerShell have no login-shell mode. Extracted `_shell_arguments()` as the single source for per-platform argv, made the integration expectation platform-aware, and added host-independent regression tests that exercise both POSIX and Windows argument construction on any runner.

## Configurable sshdesk-remote timeout
`_remote_request` hardcoded a 30 second SSH timeout, so full-resolution screenshot requests over slow links failed spuriously. Added `--timeout` to `sshdesk-remote` (default unchanged at 30) and rejected non-positive values. Also caught `subprocess.TimeoutExpired` in `remote_entrypoint`: it is a `SubprocessError`, not an `OSError`, so expiries previously escaped the error handler and printed a traceback instead of a clean message.

## Corrected override error messages
SSHDESK_MOUSE / SSHDESK_UNICODE validators accept auto plus 0/1, false/true, and no/yes, but their RuntimeErrors claimed only "auto, 0, or 1" was allowed.

## Minor
Annotated the `cli._capture` return type.

## Tests
- Agent JSON session loop (previously untested): info/quit flow stops the loop; malformed, unknown, and out-of-range requests return errors without killing the session; oversized requests are rejected without parsing.
- Server interrupt paths return 130 during startup and mid-session.
- FFmpeg stderr drain: tail retention, read-error tolerance, stream-end error reporting, FPS bound enforcement.
- Shell selector argv on both POSIX and Windows, independent of host OS.
- Remote timeout passthrough, expiry reporting without traceback, and non-positive rejection.

## Verification
Fork repositories do not run GitHub Actions checks, so this was verified locally against upstream main:

- `.venv/bin/python -m unittest discover -s tests` — 88 tests OK (74 before)
- `.venv/bin/ruff check src tests` — clean
- `sh -n scripts/*.sh` — valid
- Intermediate commit ce44f00 verified in an isolated worktree (85 tests OK)